### PR TITLE
Issue 3: Update the connector to Pravega 0.8.0

### DIFF
--- a/nifi-pravega-processors/pom.xml
+++ b/nifi-pravega-processors/pom.xml
@@ -46,7 +46,7 @@ You may obtain a copy of the License at
         <dependency>
             <groupId>io.pravega</groupId>
             <artifactId>pravega-client</artifactId>
-            <version>0.7.1</version>
+            <version>0.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>


### PR DESCRIPTION
Change log description
Updated all artifact versions to 0.8.0 and test the application in Apache NiFi.

Purpose of the change
Fixes #3 

What the code does
Updates all artifact versions to 0.8.0 in the pom file.

How to verify it
Follow the README.md to build the connector and use it in standalone local Apache Nifi.

Signed-off-by: Youmin Han <Youmin.Han@dell.com>