### PR TITLE
[Issue-6] Upgrade Pravega version to 0.12.0

### DIFF
--- a/nifi-pravega-processors/pom.xml
+++ b/nifi-pravega-processors/pom.xml
@@ -21,7 +21,7 @@ You may obtain a copy of the License at
     <packaging>jar</packaging>
 
     <properties>
-        <pravega.keycloak.version>0.8.0</pravega.keycloak.version>
+        <pravega.keycloak.version>0.12.0</pravega.keycloak.version>
     </properties>
 
     <repositories>
@@ -88,7 +88,7 @@ You may obtain a copy of the License at
         <dependency>
             <groupId>io.pravega</groupId>
             <artifactId>pravega-client</artifactId>
-            <version>0.8.0</version>
+            <version>0.12.0</version>
         </dependency>
         <dependency>
             <groupId>io.pravega</groupId>


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Upgrade Pravega client and Pravega keycloak version to the latest `0.12.0`

**Purpose of the change**
Fix #6 

**What the code does**
Upgrade Pravega verions in `pom.xml`

**How to verify it**
Start a standalone Nifi cluster and a standalone Pravega cluster, all the processers deployed are working as expected